### PR TITLE
Support non-.se Loopia domains.

### DIFF
--- a/loopialib/__init__.py
+++ b/loopialib/__init__.py
@@ -1,4 +1,4 @@
-from .client import Loopia, LoopiaTest
+from .client import Loopia
 from .exceptions import LoopiaError
 from .types import DnsRecord
 from .utils import split_domain

--- a/loopialib/client.py
+++ b/loopialib/client.py
@@ -110,7 +110,3 @@ class Loopia(object):
         _validate_int("id", id)
 
         self._call("removeZoneRecord", domain, subdomain, id)
-
-
-class LoopiaTest(Loopia):
-    base_url = "https://test-api.loopia.se/RPCSERV"

--- a/loopialib/client.py
+++ b/loopialib/client.py
@@ -22,10 +22,10 @@ def _parse_status_code(response):
 
 
 class Loopia(object):
-    base_url = "https://api.loopia.se/RPCSERV"
     encoding = "utf-8"
 
-    def __init__(self, user, password):
+    def __init__(self, user, password, domain = 'se'):
+        self.base_url = f"https://api.loopia.{domain}/RPCSERV"
         self.user = user
         self.password = password
         self._client = ServerProxy(self.base_url, encoding=self.encoding)


### PR DESCRIPTION
Loopia is also a provider in Serbia but the API has a .rs base URL. This change allows accessing the API for other Loopia TLDs including .rs.